### PR TITLE
added debug call stack indent formatting. 

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,8 +13,8 @@ RoxygenNote: 5.0.1
 Roxygen: list(markdown = TRUE)
 Imports:
     crayon,
-    data.table,
-    grDevices
+    grDevices,
+    utils
 Suggests:
     covr,
     mockery,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -9,10 +9,11 @@ License: MIT + file LICENSE
 LazyData: true
 URL: https://github.com/r-lib/debugme#readme
 BugReports: https://github.com/r-lib/debugme/issues
-RoxygenNote: 5.0.1.9000
+RoxygenNote: 5.0.1
 Roxygen: list(markdown = TRUE)
-Imports: 
+Imports:
     crayon,
+    data.table,
     grDevices
 Suggests:
     covr,

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -3,4 +3,5 @@
 export(debug)
 export(debugme)
 importFrom(crayon,make_style)
+importFrom(data.table,address)
 importFrom(grDevices,colors)

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -3,5 +3,5 @@
 export(debug)
 export(debugme)
 importFrom(crayon,make_style)
-importFrom(data.table,address)
 importFrom(grDevices,colors)
+importFrom(utils,capture.output)

--- a/R/debug.R
+++ b/R/debug.R
@@ -33,23 +33,29 @@ debug <- function(msg, pkg = environmentName(topenv(parent.frame()))) {
   msg
 }
 
-#' @importFrom data.table address
+# thanks to https://stackoverflow.com/questions/18900955/get-environment-identifier-in-r
+#' @importFrom utils capture.output
+env_address <- function(env) {
+  sub('<environment: (.*)>', '\\1', capture.output(env))
+}
+
+
 update_debug_call_stack_and_compute_level <- function() {
   # -2L for update_debug_call_stack_and_compute_level() and debug() calls
   nframe <- sys.nframe() - 2L
-  level <- 0
+  level <- 0L
   frames <- sys.frames()
 
   for (call in debug_data$debug_call_stack) {
     if (call$nframe  < nframe &&
-      call$id == address(frames[[call$nframe]]))
+      call$id == env_address(frames[[call$nframe]]))
     {
       level <- call$level + 1L
       break
     }
   }
 
-  call <- list(nframe = nframe, id = address(frames[[nframe]]), level = level)
+  call <- list(nframe = nframe, id = env_address(frames[[nframe]]), level = level)
 
   if (level > 0) { # found
     debug_data$debug_call_stack <- c(list(call), debug_data$debug_call_stack)

--- a/R/package.R
+++ b/R/package.R
@@ -75,6 +75,8 @@ debugme <- function(env = topenv(parent.frame()),
 
 debug_data <- new.env()
 debug_data$timestamp <- NULL
+debug_data$debug_call_stack <- NULL
+
 
 .onLoad <- function(libname, pkgname) {
   pkgs <- parse_env_vars()

--- a/man/debug.Rd
+++ b/man/debug.Rd
@@ -16,7 +16,7 @@ automatically.}
 The original message.
 }
 \description{
-Normally this function is \emph{not} called directly, but debug strings
-are used. See \code{\link[=debugme]{debugme()}}.
+Normally this function is *not* called directly, but debug strings
+are used. See [debugme()].
 }
 

--- a/man/debugme.Rd
+++ b/man/debugme.Rd
@@ -21,38 +21,42 @@ debugging of packages via environment variables.
 }
 \details{
 To add debugging to your package, you need to
-\enumerate{
-\item Import the \code{debugme} package.
-\item Define an \code{.onLoad} function in your package, that calls \code{debugme}.
-An example:\preformatted{.onLoad <- function(libname, pkgname) { debugme::debugme() }
-}
-}
+1. Import the `debugme` package.
+2. Define an `.onLoad` function in your package, that calls `debugme`.
+   An example:
+   ```r
+   .onLoad <- function(libname, pkgname) { debugme::debugme() }
+   ```
 
-By default debugging is off. To turn on debugging, set the \code{DEBUGME}
+By default debugging is off. To turn on debugging, set the `DEBUGME`
 environment variable to the names of the packages you want to debug.
 Package names can be separated by commas.
 
-Note that \code{debugme} checks for environment variables when it is starting
+Note that `debugme` checks for environment variables when it is starting
 up. Environment variables set after the package is loaded do not have
 any effect.
 
-Example \code{debugme} entries:\preformatted{"!DEBUG Start Shiny app"
-}
+Example `debugme` entries:
+```
+"!DEBUG Start Shiny app"
+```
 }
 \section{Dynamic debug messsages}{
 
 
 It is often desired that the debug messages contain values of R
-epxressions evaluated at runtime. For example, when starting a Shiny
+expressions evaluated at runtime. For example, when starting a Shiny
 app, it is useful to also print out the path to the app. Similarly,
 when debugging an HTTP response, it is desired to log the HTTP status
 code.
 
-\code{debugme} allows embedding R code into the debug messages, within
+`debugme` allows embedding R code into the debug messages, within
 backticks. The code will be evaluated at runtime. Here are some
-examples:\preformatted{"!DEBUG Start Shiny app at `path`"
+examples:
+```
+"!DEBUG Start Shiny app at `path`"
 "!DEBUG Got HTTP response `httr::status_code(reponse)`"
-}
+```
 
 Note that parsing the debug strings for code is not very sophisticated
 currently, and you cannot embed backticks into the code itself.
@@ -61,7 +65,7 @@ currently, and you cannot embed backticks into the code itself.
 \section{Redirecting the output}{
 
 
-If the \code{DEBUGME_OUTPUT_FILE} environment variable is set to
+If the `DEBUGME_OUTPUT_FILE` environment variable is set to
 a filename, then the output is written there instead of the standard
 output stream of the R process.
 }

--- a/man/handle_dynamic_code.Rd
+++ b/man/handle_dynamic_code.Rd
@@ -11,7 +11,7 @@ handle_dynamic_code(str)
 }
 \value{
 A language expression or a string, depending on whether the
-string has dynamic code.
+  string has dynamic code.
 }
 \description{
 Substrings within backticks will be interpreted as code.

--- a/tests/testthat/test-debug.R
+++ b/tests/testthat/test-debug.R
@@ -1,6 +1,35 @@
 
 context("debug")
 
+
+test_that("debug indent", {
+  f1 <- function() {
+      debug("f1")
+      f2()
+  }
+
+  f2 <- function() {
+      debug("f2.1")
+      f3()
+      debug("f2.2")
+  }
+  f3 <- function() {
+      debug("f3")
+  }
+
+  out <- capture_output(eval({ debug("f0.1"); f1(); f2(); debug("f0.2")}))
+
+  expect_match(out, 'debugme f0.1', fixed = TRUE)
+  expect_match(out, 'debugme +-f1', fixed = TRUE)
+  expect_match(out, 'debugme   +-f2.1', fixed = TRUE)
+  expect_match(out, 'debugme     +-f3', fixed = TRUE)
+  expect_match(out, 'debugme   +-f2.2', fixed = TRUE)
+  expect_match(out, 'debugme +-f2.1', fixed = TRUE)
+  expect_match(out, 'debugme +-f2.2', fixed = TRUE)
+  expect_match(out, 'debugme f0.2', fixed = TRUE)
+})
+
+
 test_that("debug prints", {
   expect_output(
     debug("foobar", pkg = "pkg"),
@@ -47,6 +76,9 @@ test_that("debugging to a file", {
   debug("hello again!", "foo")
 
   log <- readLines(tmp)
-  expect_match(log[1], "^foobar .*hello world!$")
-  expect_match(log[2], "^foo .*hello again!$")
+  expect_match(log[1], "^foobar hello world!")
+  expect_match(log[2], "^foo hello again!")
 })
+
+
+

--- a/tests/testthat/test-debug.R
+++ b/tests/testthat/test-debug.R
@@ -29,7 +29,6 @@ test_that("debug indent", {
   expect_match(out, 'debugme f0.2', fixed = TRUE)
 })
 
-
 test_that("debug prints", {
   expect_output(
     debug("foobar", pkg = "pkg"),

--- a/tests/testthat/test-package.R
+++ b/tests/testthat/test-package.R
@@ -27,7 +27,7 @@ test_that("debugme", {
   debugme(env)
 
   expect_silent(env$f1())
-  expect_output(env$f2(), "debugme \\+[0-9]+ms foobar")
+  expect_output(env$f2(), "debugme foobar \\+[0-9]+ms")
   expect_identical(env$notme, "!DEBUG nonono")
-  expect_output(env$.hidden(), "debugme \\+[0-9]+ms foobar2")
+  expect_output(env$.hidden(), "debugme foobar2 \\+[0-9]+ms")
 })


### PR DESCRIPTION
I had to change a bit the format output, and to import data.table.

I also intend (and I think you might too) to make a package for drawing pretty trees in a terminal, that could be used here.

On a package of mine, it looks like this:
```
qbdev test_one_pkg("qbexpress") +73ms 
qbdev +-load_pkg("qbexpress") +1ms 
qbdev   +-fetch_pkg_db() +1ms 
qbdev   +-load_pkg_and_deps("qbexpress") +2ms 
qbdev     +-find_srcpkgs("/home/karl/workspace/qbr") +1ms 
qbdev     +-load_pkg_and_deps("qbutils") +46ms 
qbdev       +-load_one_pkg_if_needed pkg="qbutils" +1ms 
qbdev         +-md5sum_pkg - pkg="qbutils" dir="/home/karl/workspace/qbr/pkg/qbutils_proj/qbutils" +1ms 
qbdev           +-hook_runner(hook_name="hook_loadNamespace") +1ms 
qbdev             +-my_qbdev_loader(pkg_name="withr", hooked="loadNamespace") DISABLED +2ms 
qbdev           +-hook_runner(hook_name="hook_loadNamespace") +4ms 
qbdev             +-my_qbdev_loader(pkg_name="tools", hooked="loadNamespace") DISABLED +2ms 
qbdev         +-pkg_need_reload(qbutils) +25ms 
qbdev         +-load_one_pkg pkg="qbutils" +1ms 
qbdev           +-roxygenise_pkg("qbutils") +1ms 
qbdev             +-need_roxygen("qbutils") +1ms 
qbdev           +-roxygenise_pkg --> not needed!! +1ms 
qbdev           +-load_all_wrapper pkg="qbutils" attach=FALSE export_all=FALSE +1ms 
qbdev             +-fix_imports_for_devtools(): patching namespaceImportFrom +1ms 
qbdev               +-replace_binding(name="namespaceImportFrom") +1ms 
```

What do you think ?
