### PR TITLE
Differentiate between first and subsequent entries for the same function

### DIFF
--- a/tests/testthat/test-debug.R
+++ b/tests/testthat/test-debug.R
@@ -23,9 +23,9 @@ test_that("debug indent", {
   expect_match(out, 'debugme +-f1', fixed = TRUE)
   expect_match(out, 'debugme   +-f2.1', fixed = TRUE)
   expect_match(out, 'debugme     +-f3', fixed = TRUE)
-  expect_match(out, 'debugme   +-f2.2', fixed = TRUE)
+  expect_match(out, 'debugme    -f2.2', fixed = TRUE)
   expect_match(out, 'debugme +-f2.1', fixed = TRUE)
-  expect_match(out, 'debugme +-f2.2', fixed = TRUE)
+  expect_match(out, 'debugme  -f2.2', fixed = TRUE)
   expect_match(out, 'debugme f0.2', fixed = TRUE)
 
   out <- withr::with_envvar(


### PR DESCRIPTION
This helps understand if we're looking at debug messages from different or from the same function.

For `f()` printing one message and then calling `g()` which prints 3 messages, this gives:

Before:

```
f
+-g1
+-g2
+-g3
```

After:

```
f
+-g1
 -g2
 -g3
```