### PR TITLE
`debugme()` gains `level` argument

### DIFF
--- a/R/debug.R
+++ b/R/debug.R
@@ -7,19 +7,19 @@
 #' @param msg Message to print, character constant.
 #' @param pkg Package name to which the message belongs. Detected
 #'   automatically.
-#' @return The original message.
+#' @param level The maximum debug level to show this message at.
+#' @return Invisibly, the message if it is shown, otherwise `NULL`.
 #'
 #' @export
 
-debug <- function(msg, pkg = environmentName(topenv(parent.frame()))) {
+debug <- function(msg, pkg = environmentName(topenv(parent.frame())), level = 2) {
 
   pkg_level <- get_package_debug_level(pkg)
-  msg_level <- get_msg_debug_levels(msg)
-  if (!is.na(pkg_level) && pkg_level > 0 && pkg_level < msg_level) {
-    return(msg)
+  if (!is.na(pkg_level) && pkg_level > 0 && pkg_level < level) {
+    return(invisible(NULL))
   }
 
-  msg <- sub("^!+\\s*", "", msg)
+  force(msg)
   file <- get_output_file()
 
   time_stamp_mode <- if (file == "") "diff" else "stamp"
@@ -42,7 +42,7 @@ debug <- function(msg, pkg = environmentName(topenv(parent.frame()))) {
   style <- if (file == "") get_package_style(pkg) else identity
   cat(style(full_msg), "\n", file = file, sep = "", append = TRUE)
 
-  msg
+  invisible(msg)
 }
 
 get_log_levels <- function() {

--- a/R/instrument.R
+++ b/R/instrument.R
@@ -53,7 +53,13 @@ is_debug_string <- function(x) {
 }
 
 make_debug_call <- function(x) {
-  x <- sub("^(!+)DEBUG", "\\1", x, perl = TRUE)
-  x <- handle_dynamic_code(x)
-  as.call(list(quote(debugme::debug), x))
+  parsed <- re_match(x, "^(?<level>!+DEBUG(?:-[^ ]+)? ) *(?<text>.*)$")
+  if (nrow(parsed) != 1) {
+    return(NULL)
+  }
+
+  level <- get_msg_debug_levels(parsed$level)
+  msg <- handle_dynamic_code(parsed$text)
+
+  as.call(list(quote(debugme::debug), msg, level = level))
 }

--- a/man/debug.Rd
+++ b/man/debug.Rd
@@ -4,16 +4,18 @@
 \alias{debug}
 \title{Debug message}
 \usage{
-debug(msg, pkg = environmentName(topenv(parent.frame())))
+debug(msg, pkg = environmentName(topenv(parent.frame())), level = 2)
 }
 \arguments{
 \item{msg}{Message to print, character constant.}
 
 \item{pkg}{Package name to which the message belongs. Detected
 automatically.}
+
+\item{level}{The maximum debug level to show this message at.}
 }
 \value{
-The original message.
+Invisibly, the message if it is shown, otherwise \code{NULL}.
 }
 \description{
 Normally this function is \emph{not} called directly, but debug strings

--- a/tests/testthat/test-debug.R
+++ b/tests/testthat/test-debug.R
@@ -47,8 +47,8 @@ test_that("debug levels", {
 
   mockery::stub(debug, "get_package_debug_level", 1)
   env <- new.env()
-  env$f1 <- function() debug("!DEBUG foobar")
-  env$f2 <- function() debug("!!DEBUG baz")
+  env$f1 <- function() debug("foobar", level = 1)
+  env$f2 <- function() debug("baz", level = 2)
   expect_output(env$f1(), "foobar")
   expect_silent(env$f2())
 })

--- a/tests/testthat/test-levels.R
+++ b/tests/testthat/test-levels.R
@@ -21,12 +21,12 @@ test_that("log levels are instrumented", {
 test_that("log levels work properly", {
 
   fs <- list(
-    list("fatal",   function() debug("!DEBUG-FATAL fatal")),
-    list("error",   function() debug("!DEBUG-ERROR error")),
-    list("warning", function() debug("!DEBUG-WARNING warning")),
-    list("info",    function() debug("!DEBUG-INFO info")),
-    list("debug",   function() debug("!DEBUG-DEBUG debug")),
-    list("verbose", function() debug("!DEBUG-VERBOSE verbose"))
+    list("fatal",   function() debug("fatal", level = 1)),
+    list("error",   function() debug("error", level = 2)),
+    list("warning", function() debug("warning", level = 3)),
+    list("info",    function() debug("info", level = 4)),
+    list("debug",   function() debug("debug", level = 5)),
+    list("verbose", function() debug("verbose", level = 6))
   )
 
   for (pkg_level in 1:6) {


### PR DESCRIPTION
This allows evaluating the message lazily, and also fixes issues with detecting the appropriate log level.

The `msg` argument no longer contains the `"!DEBUG"` header, technically it's a breaking change but maybe irrelevant?